### PR TITLE
Allow more flexibility in extracting a template key

### DIFF
--- a/src/index.js
+++ b/src/index.js
@@ -4,8 +4,9 @@ function loaderFn(source) {
 	this.cacheable();
 
 	const sourcePart = source.replace("module.exports", "var htmlContent");
-	const options = utils.getOptions(this);
-	const name = (options ? options.name : null) || utils.interpolateName(this, "[name]-[ext]", {});
+	const options = utils.getOptions(this) || {};
+	const templateName = options.templateName || '[name]-[ext]';
+	const name = options.name || utils.interpolateName(this, templateName, options);
 
 	return [
 		"var ko = require('knockout');",


### PR DESCRIPTION
* introduce a new option 'templateName' which can contain all
  interpolations to be used in `interpolateName` (see
  https://www.npmjs.com/package/loader-utils#interpolatename )
* pass all options directly to `interpolateName`, so that 'regExp'
  option could be used as well (see examples in above link).