### PR TITLE
Improve string template engine and name option

### DIFF
--- a/README.md
+++ b/README.md
@@ -10,16 +10,25 @@ npm install knockout-template-loader --save-dev
 
 ## Usage
 
-Either add it to your global `webpack.config.js`:
+Either add it to your global `webpack.config.js`, chaining after the `html-loader`:
 
 ```js
 {
-	module: {
-		loaders: [{
-			test: /\.html$/,
-			loader: "knockout-template!html"
-		}]
-	}
+  module: {
+    loaders: [{
+      test: /\.html$/,
+      use: [{
+        loader: "knockout-template-loader",
+        options: {
+          name: "[name]",
+          caseInsensitive: true
+        }
+      },
+      {
+        loader: "html-loader"
+      }]
+    }]
+  }
 }
 ```
 
@@ -29,8 +38,35 @@ or, if you don't want to use it globally, on a case-by-case basis:
 require("knockout-template!html!./my-template-file.html");
 ```
 
-By default, it will make the template available to knockout using the template's file name. If you want to override that, you can specify the `name` parameter:
+## Options
+
+### `name: string | function(string) => string`
+
+By default, the loader will make the template available to knockout using the template's file name. If you want to override that, you can specify the `name` parameter. 
+
+- Use a string value utilizing the available replacement tokens, like `[name]` for filename without extension. 
+- Pass a callback function which receives the full path of the HTML file being loaded and returns a name for the template. 
+
+**Examples**
+
+```js
+...
+name: "[name]" // use file name without extension
+name: function(fullname) {
+  // use parent directory name + filename
+  var directoryName = path.basename(path.dirname(fullname));
+  var filename = path.basename(fullname).replace(/\.[^/.]+$/, "");
+  return directoryName + "-" + filename;
+}  
+...
+```
+
+Or using as an inline loader parameter:
 
 ```js
 require("knockout-template?name=myBetterName!html!./my-template-file.html");
 ```
+
+### `caseInsensitive: boolean` (default: `false`)
+
+If set to `true`, the underlying template name resolution will happen case-insensitively, otherwise it will be case sensitive.

--- a/src/index.js
+++ b/src/index.js
@@ -9,20 +9,21 @@ function loaderFn(source) {
   let name = options && options.name || "[name]-[ext]";
   
   if (typeof name === "function") {
-    const pathObject = {
-      fullpath: utils.interpolateName(this, "[path][name].[ext]", {}),
-      path: utils.interpolateName(this, "[path]", {}),
-      name: utils.interpolateName(this, "[name]", {}),
-      ext: utils.interpolateName(this, "[ext]", {})
-    };
-    name = name(pathObject);
+    name = name(utils.interpolateName(this, "[path][name].[ext]", {}));
   }
 
 	name = utils.interpolateName(this, name, {});
 
+  const caseInsensitive = options && options.caseInsensitive;
+
+  if (caseInsensitive) {
+    name = name.toLowerCase();
+  }
+
 	return [
 		"var ko = require('knockout');",
-		"var stringTemplateEngine = require('knockout-template-loader/lib/string-template-engine');",
+		"require('knockout-template-loader/lib/string-template-engine');",
+    `ko.templateSources.stringTemplate.caseInsensitive = ${(caseInsensitive ? "true" : "false")};`,
 		sourcePart,
 		`ko.templates['${name}'] = htmlContent;`
 	].join("\n");

--- a/src/index.js
+++ b/src/index.js
@@ -5,7 +5,20 @@ function loaderFn(source) {
 
 	const sourcePart = source.replace("module.exports", "var htmlContent");
 	const options = utils.getOptions(this);
-	const name = (options ? options.name : null) || utils.interpolateName(this, "[name]-[ext]", {});
+  
+  let name = options && options.name || "[name]-[ext]";
+  
+  if (typeof name === "function") {
+    const pathObject = {
+      fullpath: utils.interpolateName(this, "[path][name].[ext]", {}),
+      path: utils.interpolateName(this, "[path]", {}),
+      name: utils.interpolateName(this, "[name]", {}),
+      ext: utils.interpolateName(this, "[ext]", {})
+    };
+    name = name(pathObject);
+  }
+
+	name = utils.interpolateName(this, name, {});
 
 	return [
 		"var ko = require('knockout');",

--- a/src/string-template-engine.js
+++ b/src/string-template-engine.js
@@ -29,19 +29,27 @@ ko.utils.extend(ko.templateSources.stringTemplate.prototype, {
 	}
 });
 
-engine.makeTemplateSource = function(template, doc) {
-	var elem;
-	if(typeof template === "string") {
-		elem = (doc || document).getElementById(template);
+engine.makeTemplateSource = function(template, templateDocument) {
+  // Named template
+  if (typeof template == "string") {
+    templateDocument = templateDocument || document;
 
-		if(elem) {
-			return new ko.templateSources.domElement(elem);
-		}
+    var elem = templateDocument.getElementById(template);
+    if (elem) {
+      return new ko.templateSources.domElement(elem);
+    }
 
-		return new ko.templateSources.stringTemplate(template);
-	} else if(template && (template.nodeType == 1) || (template.nodeType == 8)) {
-		return new ko.templateSources.anonymousTemplate(template);
-	}
+    if (ko.templates[template]) {
+      return new ko.templateSources.stringTemplate(template);
+    }
+
+    throw new Error("Cannot find template with ID " + template);
+  } else if ((template.nodeType == 1) || (template.nodeType == 8)) {
+    // Anonymous template
+    return new ko.templateSources.anonymousTemplate(template);
+  } else {
+    throw new Error("Unknown template type: " + template);
+  }
 };
 
 //make the templates accessible

--- a/src/string-template-engine.js
+++ b/src/string-template-engine.js
@@ -10,6 +10,8 @@ ko.templateSources.stringTemplate = function(template) {
 	this.templateName = template;
 };
 
+ko.templateSources.stringTemplate.caseInsensitive = false;
+
 ko.utils.extend(ko.templateSources.stringTemplate.prototype, {
 	data: function(key, value) {
 		data[this.templateName] = data[this.templateName] || {};
@@ -21,7 +23,7 @@ ko.utils.extend(ko.templateSources.stringTemplate.prototype, {
 		data[this.templateName][key] = value;
 	},
 	text: function(value) {
-		if(arguments.length === 0) {
+	  if(arguments.length === 0) {
 			return templates[this.templateName];
 		}
 
@@ -39,8 +41,13 @@ engine.makeTemplateSource = function(template, templateDocument) {
       return new ko.templateSources.domElement(elem);
     }
 
-    if (ko.templates[template]) {
-      return new ko.templateSources.stringTemplate(template);
+    var templateName = template;
+    if (ko.templateSources.stringTemplate.caseInsensitive) {
+      templateName = templateName.toLowerCase();
+    }
+
+    if (ko.templates[templateName]) {
+      return new ko.templateSources.stringTemplate(templateName);
     }
 
     throw new Error("Cannot find template with ID " + template);


### PR DESCRIPTION
First of all, thank you for this package, really useful and gives great connection between `knockout` and `webpack`.

I've implemented the following improvements.

- Used the latest `knockout` code from default `makeTemplateSource`, so we have error handling, etc.
- Improved the `name` option to
  - allow using `[name]` or any other placeholder.
  - allow passing a callback having a path info parameter.

Could you please review the changes and merge/release this if you agree?